### PR TITLE
Add missing body on post resty

### DIFF
--- a/rest/resty.go
+++ b/rest/resty.go
@@ -79,6 +79,7 @@ func (service *restyService) MakePostRequest(ctx *gin.Context, url string, body 
 	var r *resty.Response
 	req := service.restyClient.R()
 	req.SetHeaderMultiValues(headers)
+	req.SetBody(body)
 
 	r, err := req.Post(url)
 


### PR DESCRIPTION
Issue:
 - When consuming the library, we get a 400 because it seems the body is not getting send to an endpoint. Found that the library was missing the statement to set the body for the request

Solution:
 add `SetBody` statement to the `MakePostRequest`