### PR TITLE
Set the port to connect on database

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -55,6 +55,7 @@ type (
 		DBName           string
 		DBPassword       string
 		DBUsername       string
+		DBPort           int
 		MaxIdleConns     int
 		MaxOpenConns     int
 		ConnMaxLifetime  time.Duration
@@ -84,6 +85,7 @@ type (
 const (
 	// default values
 	defaultMaxConnectionRetries = 3
+	defaultDbPort               = 5432
 
 	logError   logType = "error"
 	logSuccess logType = "success"
@@ -96,9 +98,12 @@ func NewService(config ServiceConfig) (Database, error) {
 	// 	config.DBPassword, config.DBHost, config.DBName)
 
 	// connection for Postgress
+	if config.DBPort == 0 {
+		config.DBPort = defaultDbPort
+	}
 	connectionString := fmt.Sprintf("host=%s port=%d user=%s "+
 		"password=%s dbname=%s sslmode=disable",
-		config.DBHost, 5432, config.DBUsername, config.DBPassword, config.DBName)
+		config.DBHost, config.DBPort, config.DBUsername, config.DBPassword, config.DBName)
 
 	// DOC: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
 	// pq dsn not support read_timeout & write_timeout

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -141,6 +141,25 @@ func Test_NewService_SetWriteAndTimeout_Success(t *testing.T) {
 	ass.NotNil(service)
 }
 
+func Test_NewService_SetDbPort_Success(t *testing.T) {
+	ass := assert.New(t)
+	dbPort := 5555
+	config := ServiceConfig{
+		DBPort: dbPort,
+	}
+	service, err := NewService(config)
+	ass.Nil(err)
+	ass.NotNil(service)
+}
+
+func Test_NewService_DefaultPort_Success(t *testing.T) {
+	ass := assert.New(t)
+	config := ServiceConfig{}
+	service, err := NewService(config)
+	ass.Nil(err)
+	ass.NotNil(service)
+}
+
 func Test_Connection_Success(t *testing.T) {
 	// given
 	ass := assert.New(t)


### PR DESCRIPTION
Add the attribute DbPort for change on the connection port for other database manager like redshift.  If the port is not set, take the Postgresql default port.